### PR TITLE
CT-2 Add check for annotation limit

### DIFF
--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -14,6 +14,20 @@ const ESLINT_TO_GITHUB_LEVELS = [
     'warning',
     'failure'
 ];
+// https://developer.github.com/v3/checks/runs/#output-object
+const ANNOTATION_LIMIT = 50;
+const buildAnnotation = (filename, msg) => {
+    const { line, endLine, severity, ruleId, message } = msg;
+    let annotation = {
+        path: filename,
+        start_line: line || 0,
+        end_line: endLine || line || 0,
+        annotation_level: ESLINT_TO_GITHUB_LEVELS[severity],
+        title: ruleId || 'ESLint',
+        message
+    };
+    return annotation;
+};
 async function eslint(filesList) {
     const { CLIEngine } = (await Promise.resolve().then(() => __importStar(require(path.join(process.cwd(), 'node_modules/eslint')))));
     const cli = new CLIEngine({ extensions: [...constants_1.EXTENSIONS_TO_LINT] });
@@ -27,17 +41,10 @@ async function eslint(filesList) {
         if (!filename)
             continue;
         for (const msg of messages) {
-            const { line, severity, ruleId, message, endLine, column, endColumn } = msg;
-            annotations.push({
-                path: filename,
-                start_line: line || 0,
-                end_line: endLine || line || 0,
-                start_column: column || 0,
-                end_column: endColumn || column || 0,
-                annotation_level: ESLINT_TO_GITHUB_LEVELS[severity],
-                title: ruleId || 'ESLint',
-                message
-            });
+            if (annotations.length >= ANNOTATION_LIMIT)
+                break;
+            const annotation = buildAnnotation(filename, msg);
+            annotations.push(annotation);
         }
     }
     return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
-    // "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictNullChecks": false,                /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */


### PR DESCRIPTION
- Check length of annotations to avoid this error
`No more than 50 items are allowed; 79 were supplied.`

- Remove `start_column` and `end_column` because it errors out on multi-line error