### PR TITLE
PLAT-731 Annotate only lines that changed

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CHECK_NAME = 'ESLint Results';
-exports.EXTENSIONS_TO_LINT = new Set(['.mjs', '.js', '.jsx', '.ts']);
+exports.EXTENSIONS_TO_LINT = new Set([
+    '.mjs',
+    '.js',
+    '.ts',
+    '.jsx',
+    '.tsx'
+]);

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -36,13 +36,9 @@ async function eslint(filesList, diff) {
     const report = cli.executeOnFiles(filesList);
     // fixableErrorCount, fixableWarningCount are available too
     const { results, errorCount, warningCount } = report;
-    console.log(filesList);
-    console.log(diff);
     const changedLinesByFilepath = git_1.getChangedLinesByFilepath(diff);
-    console.log(changedLinesByFilepath);
     const annotations = [];
     for (const result of results) {
-        console.log(result);
         const { filePath, messages } = result;
         const filename = filesList.find(file => filePath.endsWith(file));
         if (!filename)
@@ -50,11 +46,8 @@ async function eslint(filesList, diff) {
         for (const msg of messages) {
             if (annotations.length >= ANNOTATION_LIMIT)
                 break;
-            console.log(msg);
             for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++) {
                 if ((_a = changedLinesByFilepath.get(filename)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
-                    console.log(`startLine: ${msg.line}`);
-                    console.log(`endLine: ${msg.endLine}`);
                     const annotation = buildAnnotation(filename, msg);
                     annotations.push(annotation);
                     break;

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -39,6 +39,7 @@ async function eslint(filesList, diff) {
     const changedLinesByFilepath = git_1.getChangedLinesByFilepath(diff);
     const annotations = [];
     for (const result of results) {
+        console.log(result);
         const { filePath, messages } = result;
         const filename = filesList.find(file => filePath.endsWith(file));
         if (!filename)
@@ -46,7 +47,9 @@ async function eslint(filesList, diff) {
         for (const msg of messages) {
             if (annotations.length >= ANNOTATION_LIMIT)
                 break;
-            for (let lineNumber = msg.line || 0; lineNumber <= msg.endLine || msg.line || 0; lineNumber++) {
+            console.log(msg);
+            for (let lineNumber = (msg.line || 0); lineNumber <= (msg.endLine || msg.line || 0); lineNumber++) {
+                console.log(lineNumber);
                 if ((_a = changedLinesByFilepath.get(filename)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
                     const annotation = buildAnnotation(filename, msg);
                     annotations.push(annotation);

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -49,6 +49,7 @@ async function eslint(filesList, diff) {
         for (const msg of messages) {
             if (annotations.length >= ANNOTATION_LIMIT)
                 break;
+            console.log(msg);
             for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++) {
                 if ((_a = changedLinesByFilepath.get(filePath)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
                     console.log(`startLine: ${msg.line}`);

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -46,7 +46,7 @@ async function eslint(filesList, diff) {
         for (const msg of messages) {
             if (annotations.length >= ANNOTATION_LIMIT)
                 break;
-            for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++) {
+            for (let lineNumber = msg.line || 0; lineNumber <= msg.endLine || msg.line || 0; lineNumber++) {
                 if ((_a = changedLinesByFilepath.get(filename)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
                     const annotation = buildAnnotation(filename, msg);
                     annotations.push(annotation);

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -9,6 +9,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const path = __importStar(require("path"));
 const constants_1 = require("./constants");
+const git_1 = require("./git");
 const ESLINT_TO_GITHUB_LEVELS = [
     'notice',
     'warning',
@@ -28,12 +29,13 @@ const buildAnnotation = (filename, msg) => {
     };
     return annotation;
 };
-async function eslint(filesList) {
+async function eslint(filesList, diff) {
     const { CLIEngine } = (await Promise.resolve().then(() => __importStar(require(path.join(process.cwd(), 'node_modules/eslint')))));
     const cli = new CLIEngine({ extensions: [...constants_1.EXTENSIONS_TO_LINT] });
     const report = cli.executeOnFiles(filesList);
     // fixableErrorCount, fixableWarningCount are available too
     const { results, errorCount, warningCount } = report;
+    const changedLinesByFilepath = git_1.getChangedLinesByFilepath(diff);
     const annotations = [];
     for (const result of results) {
         const { filePath, messages } = result;
@@ -43,8 +45,13 @@ async function eslint(filesList) {
         for (const msg of messages) {
             if (annotations.length >= ANNOTATION_LIMIT)
                 break;
-            const annotation = buildAnnotation(filename, msg);
-            annotations.push(annotation);
+            for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++) {
+                if (changedLinesByFilepath.get(filePath).has(lineNumber)) {
+                    const annotation = buildAnnotation(filename, msg);
+                    annotations.push(annotation);
+                    break;
+                }
+            }
         }
     }
     return {

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -39,7 +39,6 @@ async function eslint(filesList, diff) {
     const changedLinesByFilepath = git_1.getChangedLinesByFilepath(diff);
     const annotations = [];
     for (const result of results) {
-        console.log(result);
         const { filePath, messages } = result;
         const filename = filesList.find(file => filePath.endsWith(file));
         if (!filename)
@@ -47,9 +46,7 @@ async function eslint(filesList, diff) {
         for (const msg of messages) {
             if (annotations.length >= ANNOTATION_LIMIT)
                 break;
-            console.log(msg);
             for (let lineNumber = (msg.line || 0); lineNumber <= (msg.endLine || msg.line || 0); lineNumber++) {
-                console.log(lineNumber);
                 if ((_a = changedLinesByFilepath.get(filename)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
                     const annotation = buildAnnotation(filename, msg);
                     annotations.push(annotation);

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -30,6 +30,7 @@ const buildAnnotation = (filename, msg) => {
     return annotation;
 };
 async function eslint(filesList, diff) {
+    var _a;
     const { CLIEngine } = (await Promise.resolve().then(() => __importStar(require(path.join(process.cwd(), 'node_modules/eslint')))));
     const cli = new CLIEngine({ extensions: [...constants_1.EXTENSIONS_TO_LINT] });
     const report = cli.executeOnFiles(filesList);
@@ -46,7 +47,7 @@ async function eslint(filesList, diff) {
             if (annotations.length >= ANNOTATION_LIMIT)
                 break;
             for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++) {
-                if (changedLinesByFilepath.get(filePath).has(lineNumber)) {
+                if ((_a = changedLinesByFilepath.get(filePath)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
                     const annotation = buildAnnotation(filename, msg);
                     annotations.push(annotation);
                     break;

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -42,6 +42,7 @@ async function eslint(filesList, diff) {
     console.log(changedLinesByFilepath);
     const annotations = [];
     for (const result of results) {
+        console.log(result);
         const { filePath, messages } = result;
         const filename = filesList.find(file => filePath.endsWith(file));
         if (!filename)
@@ -51,7 +52,7 @@ async function eslint(filesList, diff) {
                 break;
             console.log(msg);
             for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++) {
-                if ((_a = changedLinesByFilepath.get(filePath)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
+                if ((_a = changedLinesByFilepath.get(filename)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
                     console.log(`startLine: ${msg.line}`);
                     console.log(`endLine: ${msg.endLine}`);
                     const annotation = buildAnnotation(filename, msg);

--- a/lib/eslint-cli.js
+++ b/lib/eslint-cli.js
@@ -36,7 +36,10 @@ async function eslint(filesList, diff) {
     const report = cli.executeOnFiles(filesList);
     // fixableErrorCount, fixableWarningCount are available too
     const { results, errorCount, warningCount } = report;
+    console.log(filesList);
+    console.log(diff);
     const changedLinesByFilepath = git_1.getChangedLinesByFilepath(diff);
+    console.log(changedLinesByFilepath);
     const annotations = [];
     for (const result of results) {
         const { filePath, messages } = result;
@@ -48,6 +51,8 @@ async function eslint(filesList, diff) {
                 break;
             for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++) {
                 if ((_a = changedLinesByFilepath.get(filePath)) === null || _a === void 0 ? void 0 : _a.has(lineNumber)) {
+                    console.log(`startLine: ${msg.line}`);
+                    console.log(`endLine: ${msg.endLine}`);
                     const annotation = buildAnnotation(filename, msg);
                     annotations.push(annotation);
                     break;

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,0 +1,40 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const getChangedLinesFromHunk = (hunk) => {
+    let lineNumber = 0;
+    const changedLines = [];
+    for (const line of hunk) {
+        if (line.startsWith('@@')) {
+            lineNumber = Number(line.match(/\+([0-9]+)/)[1]);
+            continue;
+        }
+        if (!line.startsWith('-')) {
+            if (line.startsWith('+') && lineNumber != 0) {
+                changedLines.push(lineNumber);
+            }
+            lineNumber++;
+        }
+    }
+    return changedLines;
+};
+const getHunksFromDiff = (str) => {
+    const lines = str.split('\n');
+    const hunks = [];
+    let i = -1;
+    for (const line of lines) {
+        if (line.startsWith('diff --git')) {
+            i++;
+            hunks[i] = [];
+        }
+        hunks[i].push(line);
+    }
+    return hunks;
+};
+exports.getChangedLinesByFilepath = (diff) => {
+    const changedLinesByFile = new Map();
+    for (const hunk of getHunksFromDiff(diff)) {
+        const file = hunk[0].split(' ')[3].substring(2);
+        changedLinesByFile.set(file, new Set(getChangedLinesFromHunk(hunk.slice(4))));
+    }
+    return changedLinesByFile;
+};

--- a/lib/git.js
+++ b/lib/git.js
@@ -2,20 +2,18 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const getChangedLinesFromHunk = (hunk) => {
     let lineNumber = 0;
-    const changedLines = [];
-    for (const line of hunk) {
+    return hunk.reduce((accum, line) => {
         if (line.startsWith('@@')) {
             lineNumber = Number(line.match(/\+([0-9]+)/)[1]);
-            continue;
         }
-        if (!line.startsWith('-')) {
-            if (line.startsWith('+') && lineNumber != 0) {
-                changedLines.push(lineNumber);
+        else if (!line.startsWith('-')) {
+            if (line.startsWith('+') && lineNumber !== 0) {
+                accum.push(lineNumber);
             }
             lineNumber++;
         }
-    }
-    return changedLines;
+        return accum;
+    }, []);
 };
 const getHunksFromDiff = (str) => {
     const lines = str.split('\n');

--- a/lib/main.js
+++ b/lib/main.js
@@ -26,6 +26,14 @@ const gql = (s) => s.join('');
 async function run() {
     const octokit = new github.GitHub(core.getInput('repo-token', { required: true }));
     const context = github.context;
+    const { data: diff } = await octokit.pulls.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: context.issue.number,
+        mediaType: {
+            format: "diff",
+        }
+    });
     const prInfo = await octokit.graphql(gql `
       query($owner: String!, $name: String!, $prNumber: Int!) {
         repository(owner: $owner, name: $name) {
@@ -85,7 +93,7 @@ async function run() {
         })).data.id;
     }
     try {
-        const { conclusion, output } = await eslint_cli_1.eslint(filesToLint);
+        const { conclusion, output } = await eslint_cli_1.eslint(filesToLint, diff); // workaround for https://github.com/probot/probot/issues/1026
         await octokit.checks.update({
             ...context.repo,
             check_run_id: checkId,

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -48,7 +48,7 @@ export async function eslint(filesList: string[], diff: string) {
 
     for (const msg of messages) {
       if (annotations.length >= ANNOTATION_LIMIT) break;
-      for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
+      for (let lineNumber = msg.line || 0; lineNumber <= msg.endLine || msg.line || 0; lineNumber++)
       {
         if (changedLinesByFilepath.get(filename)?.has(lineNumber)) {
           const annotation = buildAnnotation(filename, msg);

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -38,8 +38,10 @@ export async function eslint(filesList: string[], diff: string) {
   // fixableErrorCount, fixableWarningCount are available too
   const { results, errorCount, warningCount } = report;
 
-
+  console.log(filesList)
+  console.log(diff)
   const changedLinesByFilepath = getChangedLinesByFilepath(diff)
+  console.log(changedLinesByFilepath)
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
@@ -49,7 +51,8 @@ export async function eslint(filesList: string[], diff: string) {
 
     for (const msg of messages) {
       if (annotations.length >= ANNOTATION_LIMIT) break;
-
+      console.log(`startLine: ${msg.line}`)
+      console.log(`endLine: ${msg.endLine}`)
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
         if (changedLinesByFilepath.get(filePath).has(lineNumber)) {

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -42,17 +42,13 @@ export async function eslint(filesList: string[], diff: string) {
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
-    console.log(result);
     const { filePath, messages } = result;
     const filename = filesList.find(file => filePath.endsWith(file));
     if (!filename) continue;
 
     for (const msg of messages) {
       if (annotations.length >= ANNOTATION_LIMIT) break;
-      console.log(msg);
-      for (let lineNumber = (msg.line || 0); lineNumber <= (msg.endLine || msg.line || 0); lineNumber++)
-      {
-        console.log(lineNumber);
+      for (let lineNumber = (msg.line || 0); lineNumber <= (msg.endLine || msg.line || 0); lineNumber++) {
         if (changedLinesByFilepath.get(filename)?.has(lineNumber)) {
           const annotation = buildAnnotation(filename, msg);
           annotations.push(annotation);

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -38,7 +38,10 @@ export async function eslint(filesList: string[], diff: string) {
   // fixableErrorCount, fixableWarningCount are available too
   const { results, errorCount, warningCount } = report;
 
+  console.log(filesList)
+  console.log(diff)
   const changedLinesByFilepath = getChangedLinesByFilepath(diff)
+  console.log(changedLinesByFilepath)
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
@@ -52,6 +55,8 @@ export async function eslint(filesList: string[], diff: string) {
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
         if (changedLinesByFilepath.get(filePath)?.has(lineNumber)) {
+          console.log(`startLine: ${msg.line}`)
+          console.log(`endLine: ${msg.endLine}`)
           const annotation = buildAnnotation(filename, msg);
           annotations.push(annotation);
           break;

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -6,6 +6,8 @@ import { EXTENSIONS_TO_LINT } from './constants';
 
 import { getChangedLinesByFilepath } from './git'
 
+import * as core from '@actions/core';
+
 const ESLINT_TO_GITHUB_LEVELS: ChecksUpdateParamsOutputAnnotations['annotation_level'][] = [
   'notice',
   'warning',
@@ -38,10 +40,10 @@ export async function eslint(filesList: string[], diff: string) {
   // fixableErrorCount, fixableWarningCount are available too
   const { results, errorCount, warningCount } = report;
 
-  console.log(filesList)
-  console.log(diff)
+  core.info(JSON.stringify(filesList))
+  core.info(diff)
   const changedLinesByFilepath = getChangedLinesByFilepath(diff)
-  console.log(changedLinesByFilepath)
+  core.info(JSON.stringify(changedLinesByFilepath))
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
@@ -51,8 +53,8 @@ export async function eslint(filesList: string[], diff: string) {
 
     for (const msg of messages) {
       if (annotations.length >= ANNOTATION_LIMIT) break;
-      console.log(`startLine: ${msg.line}`)
-      console.log(`endLine: ${msg.endLine}`)
+      core.info(`startLine: ${msg.line}`)
+      core.info(`endLine: ${msg.endLine}`)
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
         if (changedLinesByFilepath.get(filePath).has(lineNumber)) {

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -51,7 +51,7 @@ export async function eslint(filesList: string[], diff: string) {
 
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
-        if (changedLinesByFilepath.get(filePath).has(lineNumber)) {
+        if (changedLinesByFilepath.get(filePath)?.has(lineNumber)) {
           const annotation = buildAnnotation(filename, msg);
           annotations.push(annotation);
           break;

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -38,26 +38,19 @@ export async function eslint(filesList: string[], diff: string) {
   // fixableErrorCount, fixableWarningCount are available too
   const { results, errorCount, warningCount } = report;
 
-  console.log(filesList)
-  console.log(diff)
   const changedLinesByFilepath = getChangedLinesByFilepath(diff)
-  console.log(changedLinesByFilepath)
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
-    console.log(result);
     const { filePath, messages } = result;
     const filename = filesList.find(file => filePath.endsWith(file));
     if (!filename) continue;
 
     for (const msg of messages) {
       if (annotations.length >= ANNOTATION_LIMIT) break;
-      console.log(msg);
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
         if (changedLinesByFilepath.get(filename)?.has(lineNumber)) {
-          console.log(`startLine: ${msg.line}`)
-          console.log(`endLine: ${msg.endLine}`)
           const annotation = buildAnnotation(filename, msg);
           annotations.push(annotation);
           break;

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -42,14 +42,17 @@ export async function eslint(filesList: string[], diff: string) {
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
+    console.log(result);
     const { filePath, messages } = result;
     const filename = filesList.find(file => filePath.endsWith(file));
     if (!filename) continue;
 
     for (const msg of messages) {
       if (annotations.length >= ANNOTATION_LIMIT) break;
-      for (let lineNumber = msg.line || 0; lineNumber <= msg.endLine || msg.line || 0; lineNumber++)
+      console.log(msg);
+      for (let lineNumber = (msg.line || 0); lineNumber <= (msg.endLine || msg.line || 0); lineNumber++)
       {
+        console.log(lineNumber);
         if (changedLinesByFilepath.get(filename)?.has(lineNumber)) {
           const annotation = buildAnnotation(filename, msg);
           annotations.push(annotation);

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -6,8 +6,6 @@ import { EXTENSIONS_TO_LINT } from './constants';
 
 import { getChangedLinesByFilepath } from './git'
 
-import * as core from '@actions/core';
-
 const ESLINT_TO_GITHUB_LEVELS: ChecksUpdateParamsOutputAnnotations['annotation_level'][] = [
   'notice',
   'warning',
@@ -40,10 +38,7 @@ export async function eslint(filesList: string[], diff: string) {
   // fixableErrorCount, fixableWarningCount are available too
   const { results, errorCount, warningCount } = report;
 
-  core.info(JSON.stringify(filesList))
-  core.info(diff)
   const changedLinesByFilepath = getChangedLinesByFilepath(diff)
-  core.info(JSON.stringify(changedLinesByFilepath))
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
@@ -53,8 +48,7 @@ export async function eslint(filesList: string[], diff: string) {
 
     for (const msg of messages) {
       if (annotations.length >= ANNOTATION_LIMIT) break;
-      core.info(`startLine: ${msg.line}`)
-      core.info(`endLine: ${msg.endLine}`)
+
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
         if (changedLinesByFilepath.get(filePath).has(lineNumber)) {

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -4,7 +4,7 @@ import { ChecksUpdateParamsOutputAnnotations } from '@octokit/rest';
 
 import { EXTENSIONS_TO_LINT } from './constants';
 
-import { getChangedLinesByFile } from './git'
+import { getChangedLinesByFilepath } from './git'
 
 const ESLINT_TO_GITHUB_LEVELS: ChecksUpdateParamsOutputAnnotations['annotation_level'][] = [
   'notice',
@@ -39,7 +39,7 @@ export async function eslint(filesList: string[], diff: string) {
   const { results, errorCount, warningCount } = report;
 
 
-  const changedLinesByFile = getChangedLinesByFile(diff)
+  const changedLinesByFilepath = getChangedLinesByFilepath(diff)
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
@@ -52,7 +52,7 @@ export async function eslint(filesList: string[], diff: string) {
 
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
-        if (changedLinesByFile.get(filePath).has(lineNumber)) {
+        if (changedLinesByFilepath.get(filePath).has(lineNumber)) {
           const annotation = buildAnnotation(filename, msg);
           annotations.push(annotation);
           break;

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -51,7 +51,7 @@ export async function eslint(filesList: string[], diff: string) {
 
     for (const msg of messages) {
       if (annotations.length >= ANNOTATION_LIMIT) break;
-
+      console.log(msg);
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
         if (changedLinesByFilepath.get(filePath)?.has(lineNumber)) {

--- a/src/eslint-cli.ts
+++ b/src/eslint-cli.ts
@@ -45,6 +45,7 @@ export async function eslint(filesList: string[], diff: string) {
 
   const annotations: ChecksUpdateParamsOutputAnnotations[] = [];
   for (const result of results) {
+    console.log(result);
     const { filePath, messages } = result;
     const filename = filesList.find(file => filePath.endsWith(file));
     if (!filename) continue;
@@ -54,7 +55,7 @@ export async function eslint(filesList: string[], diff: string) {
       console.log(msg);
       for (let lineNumber = msg.line; lineNumber <= msg.endLine; lineNumber++)
       {
-        if (changedLinesByFilepath.get(filePath)?.has(lineNumber)) {
+        if (changedLinesByFilepath.get(filename)?.has(lineNumber)) {
           console.log(`startLine: ${msg.line}`)
           console.log(`endLine: ${msg.endLine}`)
           const annotation = buildAnnotation(filename, msg);

--- a/src/git.ts
+++ b/src/git.ts
@@ -40,7 +40,7 @@ export const getChangedLinesByFile = (diff) => {
 
   for (const hunk of getHunksFromDiff(diff)) {
     const file = hunk[0].split(' ')[3].substring(2);
-    changedLinesByFile.set(file, getChangedLinesFromHunk(hunk));
+    changedLinesByFile.set(file, new Set(getChangedLinesFromHunk(hunk.slice(4))));
   }
   return changedLinesByFile;
 };

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,22 +1,18 @@
 const getChangedLinesFromHunk = (hunk) => {
   let lineNumber = 0;
-  const changedLines = [];
 
-  for (const line of hunk) {
+  return hunk.reduce((accum, line) => {
     if (line.startsWith('@@')) {
       lineNumber = Number(line.match(/\+([0-9]+)/)[1]);
-      continue;
-    }
-
-    if (!line.startsWith('-')) {
-      if (line.startsWith('+') && lineNumber != 0) {
-        changedLines.push(lineNumber);
+    } else if (!line.startsWith('-')) {
+      if (line.startsWith('+') && lineNumber !== 0) {
+        accum.push(lineNumber);
       }
       lineNumber++;
     }
-  }
-
-  return changedLines;
+    
+    return accum;
+  }, []);
 };
 
 const getHunksFromDiff = (str) => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -35,12 +35,12 @@ const getHunksFromDiff = (str) => {
   return hunks;
 };
 
-export const getChangedLinesByFile = (diff) => {
-  const changedLinesByFile = new Map();
+export const getChangedLinesByFilepath = (diff) => {
+  const changedLinesByFilepath = new Map();
 
   for (const hunk of getHunksFromDiff(diff)) {
     const file = hunk[0].split(' ')[3].substring(2);
     changedLinesByFile.set(file, new Set(getChangedLinesFromHunk(hunk.slice(4))));
   }
-  return changedLinesByFile;
+  return changedLinesByFilepath;
 };

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,46 @@
+const getChangedLinesFromHunk = (hunk) => {
+  let lineNumber = 0;
+  const changedLines = [];
+
+  for (const line of hunk) {
+    if (line.startsWith('@@')) {
+      lineNumber = Number(line.match(/\+([0-9]+)/)[1]);
+      continue;
+    }
+
+    if (!line.startsWith('-')) {
+      if (line.startsWith('+') && lineNumber != 0) {
+        changedLines.push(lineNumber);
+      }
+      lineNumber++;
+    }
+  }
+
+  return changedLines;
+};
+
+const getHunksFromDiff = (str) => {
+  const lines = str.split('\n');
+  const hunks = [];
+  let i = -1;
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git')) {
+      i++;
+      hunks[i] = [];
+    }
+    hunks[i].push(line);
+  }
+
+  return hunks;
+};
+
+export const getChangedLinesByFile = (diff) => {
+  const changedLinesByFile = new Map();
+
+  for (const hunk of getHunksFromDiff(diff)) {
+    const file = hunk[0].split(' ')[3].substring(2);
+    changedLinesByFile.set(file, getChangedLinesFromHunk(hunk));
+  }
+  return changedLinesByFile;
+};

--- a/src/git.ts
+++ b/src/git.ts
@@ -36,11 +36,11 @@ const getHunksFromDiff = (str) => {
 };
 
 export const getChangedLinesByFilepath = (diff) => {
-  const changedLinesByFilepath = new Map();
+  const changedLinesByFile = new Map();
 
   for (const hunk of getHunksFromDiff(diff)) {
     const file = hunk[0].split(' ')[3].substring(2);
     changedLinesByFile.set(file, new Set(getChangedLinesFromHunk(hunk.slice(4))));
   }
-  return changedLinesByFilepath;
+  return changedLinesByFile;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,15 @@ async function run() {
   );
   const context = github.context;
 
+  const { data : diff } = await octokit.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.issue.number,
+    mediaType: {
+      format: "diff",
+    }
+  })
+
   const prInfo = await octokit.graphql(
     gql`
       query($owner: String!, $name: String!, $prNumber: Int!) {
@@ -90,7 +99,7 @@ async function run() {
   }
 
   try {
-    const { conclusion, output } = await eslint(filesToLint);
+    const { conclusion, output } = await eslint(filesToLint, diff as any as string); // workaround for https://github.com/probot/probot/issues/1026
     await octokit.checks.update({
       ...context.repo,
       check_run_id: checkId,


### PR DESCRIPTION
The overall approach is to leverage the diff media type to retrieve changed line numbers from the github API and filter check messages based on them ([before](https://github.com/better/mortgage/pull/54233/files) & [after](https://github.com/better/mortgage/pull/54237/files)).